### PR TITLE
Set the application flag to be able to override the app id

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,7 @@ GJS_MIN_VERSION=1.39.91
 PKG_CHECK_MODULES([DEPS], [gdk-3.0
                            gdk-pixbuf-2.0
                            gio-2.0
-                           glib-2.0
+                           glib-2.0 >= 2.48
                            gobject-2.0
                            gtk+-3.0 >= 3.11.4
                            libgeoclue-2.0 >= 2.3.1

--- a/src/app/main.js
+++ b/src/app/main.js
@@ -48,7 +48,8 @@ const Application = new Lang.Class({
     Extends: Gtk.Application,
 
     _init: function() {
-        this.parent({ application_id: pkg.name });
+        this.parent({ application_id: pkg.name,
+                      flags: Gio.ApplicationFlags.CAN_OVERRIDE_APP_ID });
         GLib.set_application_name(_("Weather"));
         Gtk.Window.set_default_icon_name("org.gnome.Weather");
     },


### PR DESCRIPTION
This allows to override the application ID from the command line with --gapplication-app-id, which has been introduced in GLib 2.48. This is useful when modifying GNOME Weather in GNOME Builder using the flatpak tools and run the modified application and the original one at the same time.